### PR TITLE
Add automatic docker build/publish using github actions

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -3,6 +3,8 @@ name: Docker Image CI
 on:
     push:
         branches: [ "main" ]
+        tags:
+        - 'v*'
     pull_request:
         branches: [ "main" ]
     workflow_dispatch:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,78 @@
+name: Docker Image CI
+
+on:
+    push:
+        branches: [ "main" ]
+    pull_request:
+        branches: [ "main" ]
+    workflow_dispatch:
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: true
+
+    permissions:
+        id-token: write
+        packages: write
+        contents: read
+        attestations: write
+
+    steps:
+    - 
+        name: checkout
+        uses: actions/checkout@v4
+
+    - 
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+    
+    - 
+        name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+            install: true
+
+    - 
+        name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+            images: |
+                ghcr.io/${{ github.repository_owner }}/imdb-to-overseerr
+            tags: |
+                type=semver,pattern={{major}}
+                type=semver,pattern={{major}}.{{minor}}
+                type=semver,pattern={{version}}
+
+                type=edge,branch=main
+                type=ref,event=branch
+                type=ref,event=pr
+    -
+        name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        if: github.event_name != 'pull_request'
+        with:
+            registry: ghcr.io
+            username: ${{ github.actor }}
+            password: ${{ secrets.GITHUB_TOKEN }}
+
+    -
+        name: Build container
+        id: push
+        uses: docker/build-push-action@v5
+        with:
+            context: .
+            file: ./Dockerfile
+            # platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6,linux/s390x
+            platforms: linux/amd64,linux/arm64
+            push: ${{ github.event_name != 'pull_request' }}
+            tags: ${{ steps.meta.outputs.tags }}
+            labels: ${{ steps.meta.outputs.labels }}
+            provenance: mode=max
+            sbom: true


### PR DESCRIPTION
pushing to `main` will create an `edge` tag for the bleeding edge release. 
creating a release tag of in the format of `v1.2.3` will publish a versioned release & update the `latest` tag

Example: https://github.com/adamus1red/imdb-to-overseerr/pkgs/container/imdb-to-overseerr